### PR TITLE
Fix reST indentation and display

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         padding: .5em 1em;
         display: block;
         margin: 1em 0;
+        text-align: left;
       }
     </style>
   </head>
@@ -37,8 +38,8 @@
     <p>Or, if you use ReStructured text:
     <code>
 .. image:: http://unmaintained.tech/badge.svg<br/>
-    :target: http://unmaintained.tech/<br/>
-    :alt: No Maintenance Intended
+   :target: http://unmaintained.tech/<br/>
+   :alt: No Maintenance Intended
     </code>
     <p><a href="https://github.com/potch/unmaintained.tech">This project <i>is</i> maintained and is on GitHub!</a>
   </body>


### PR DESCRIPTION
Using 3 spaces makes block contents nicely aligned with the opening directive; the CSS edit improves the display.

To fix #10, I think we need something like `whitespace: pre`.

I would also replace code+br with a blockquote, if the maintainers agree.