### PR TITLE
Clear PRE element to prevent float

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         margin: 1em 0;
         text-align: left;
         overflow: auto;
+        clear: both;
       }
     </style>
   </head>


### PR DESCRIPTION
Added a `clear: both` to prevent the PRE element from floating. This is from Chrome: Version 131.0.6778.69 (Official Build) (arm64) on the Mac.

![CleanShot 2024-11-18 at 10 12 38@2x](https://github.com/user-attachments/assets/3a66c1df-58d5-461f-a35f-60c0be1059ee)
